### PR TITLE
[SEC] Cierra el bypass de autenticación/autorización y endurece permisos

### DIFF
--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -1,10 +1,21 @@
+import { config as dotenvConfig } from 'dotenv';
+dotenvConfig({ path: '.env.development' });
+
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { SeedService } from './seeds/seed.service'; // Importa el SeedService
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Activa las validaciones de class-validator declaradas en los DTOs
+  // (antes eran solo metadata para Swagger y nunca se ejecutaban).
+  // Sin whitelist/forbidNonWhitelisted por ahora: varios DTOs tienen
+  // objetos anidados (pax, roomType, ubicacion) sin @Type()/@ValidateNested(),
+  // y activar esas opciones los rechazaría o vaciaría en runtime.
+  app.useGlobalPipes(new ValidationPipe());
 
   // Habilitar CORS con la configuración adecuada
   app.enableCors({

--- a/back/src/modules/Auth/auth.service.ts
+++ b/back/src/modules/Auth/auth.service.ts
@@ -69,22 +69,20 @@ export class AuthService {
   }
 
   async signUp(user: Partial<Users>) {
-    const { email, password, role, locations: locationIds = [] } = user;
+    const { email, password, locations: locationIds = [] } = user;
 
     const foundUser = await this.userRepository.getUserByEmail(email);
     if (foundUser) throw new BadRequestException('Registered Email');
 
-    if (!Object.values(Role).includes(role as Role)) {
-      throw new BadRequestException(
-        'Invalid role. Allowed roles are: admin, receptionist, employee',
-      );
-    }
-
     const hashedPassword = await bcrypt.hash(password, 10);
     const locations = await this.locationRepository.findByIds(locationIds);
 
+    // El alta pública nunca puede auto-asignarse un rol: se fuerza siempre
+    // al de menor privilegio. Roles superiores solo los asigna un admin
+    // autenticado desde POST/PUT /users.
     const newUser = await this.userRepository.createUser({
       ...user,
+      role: Role.Emplo,
       password: hashedPassword,
       locations: locations
     });

--- a/back/src/modules/Auth/guards/auth.guard.ts
+++ b/back/src/modules/Auth/guards/auth.guard.ts
@@ -40,7 +40,7 @@ export class AuthGuard implements CanActivate {
         throw new ForbiddenException('User does not have a valid role');
       }
 
-      const user = await this.usersService.findOneById(payload.sub);
+      const user = await this.usersService.findOneById(payload.id);
       if (!user) {
         throw new UnauthorizedException('User not found');
       }

--- a/back/src/modules/SalesOrder/salesOrder.controller.ts
+++ b/back/src/modules/SalesOrder/salesOrder.controller.ts
@@ -1,12 +1,15 @@
-import { Controller, Post, Body, Param, Get } from '@nestjs/common';
+import { Controller, Post, Body, Param, Get, UseGuards } from '@nestjs/common';
 import { SalesOrderService } from './salesOrder.service';
 import { CreateSalesOrderDto } from './dto/salesOrder.dto';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiParam, ApiBody } from '@nestjs/swagger';
 import { ConfirmSalesOrderDto } from './dto/confirmOrder.dto';
+import { AuthGuard } from '../Auth/guards/auth.guard';
+import { RolesGuard } from '../Auth/guards/roles.guard';
 
 @ApiTags('Sales Orders')
 @Controller('salesOrders')
 @ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class SalesOrderController {
   constructor(private salesOrderService: SalesOrderService) {}
 

--- a/back/src/modules/SalesOrder/salesOrder.module.ts
+++ b/back/src/modules/SalesOrder/salesOrder.module.ts
@@ -13,6 +13,7 @@ import { UsersModule } from '../Users/users.module';
 import { LocationModule } from '../Location/location.module'; 
 import { UsersRepository } from '../Users/users.repository';
 import { Users } from '../Users/entities/users.entity';
+import { AuthModule } from '../Auth/auth.module';
 
 @Module({
   imports: [
@@ -21,7 +22,8 @@ import { Users } from '../Users/entities/users.entity';
     SalesOrderLineModule,
     ProductsModule,
     UsersModule,
-    LocationModule, 
+    LocationModule,
+    AuthModule,
   ],
   providers: [
     SalesOrderService,

--- a/back/src/modules/SalesOrderLine/salesOrderLine.controller.ts
+++ b/back/src/modules/SalesOrderLine/salesOrderLine.controller.ts
@@ -1,11 +1,14 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, UseGuards } from '@nestjs/common';
 import { SalesOrderLineService } from './salesOrderLine.service';
 import { CreateSalesOrderLineDto } from './dto/salesOrderLine.dto';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
+import { AuthGuard } from '../Auth/guards/auth.guard';
+import { RolesGuard } from '../Auth/guards/roles.guard';
 
 @ApiTags('Sales Order Lines')
 @Controller('salesOrderLines')
 @ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class SalesOrderLineController {
   constructor(private salesOrderLineService: SalesOrderLineService) {}
 

--- a/back/src/modules/SalesOrderLine/salesOrderLine.module.ts
+++ b/back/src/modules/SalesOrderLine/salesOrderLine.module.ts
@@ -4,9 +4,16 @@ import { SalesOrderLineService } from './salesOrderLine.service';
 import { SalesOrderLineController } from './salesOrderLine.controller';
 import { SalesOrderLineRepository } from './salesOrderLine.repository';
 import { SalesOrderLine } from './entities/salesOrderLine.entity';
+import { Product } from '../products/entities/product.entity';
+import { AuthModule } from '../Auth/auth.module';
+import { UsersModule } from '../Users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([SalesOrderLine])],
+  imports: [
+    TypeOrmModule.forFeature([SalesOrderLine, Product]),
+    AuthModule,
+    UsersModule,
+  ],
   providers: [SalesOrderLineService, SalesOrderLineRepository],
   controllers: [SalesOrderLineController],
   exports: [SalesOrderLineRepository], 

--- a/back/src/modules/SalesOrderLine/salesOrderLine.service.ts
+++ b/back/src/modules/SalesOrderLine/salesOrderLine.service.ts
@@ -1,20 +1,33 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { SalesOrderLineRepository } from './salesOrderLine.repository';
 import { CreateSalesOrderLineDto } from './dto/salesOrderLine.dto';
+import { Product } from '../products/entities/product.entity';
 
 @Injectable()
 export class SalesOrderLineService {
   constructor(
     @InjectRepository(SalesOrderLineRepository)
     private salesOrderLineRepository: SalesOrderLineRepository,
+    @InjectRepository(Product)
+    private productRepository: Repository<Product>,
   ) {}
 
   async createSalesOrderLine(createSalesOrderLineDto: CreateSalesOrderLineDto) {
+    const { productId, ...rest } = createSalesOrderLineDto;
+
+    const product = await this.productRepository.findOne({
+      where: { id: productId },
+    });
+    if (!product) {
+      throw new NotFoundException('Producto no encontrado');
+    }
 
     const line = this.salesOrderLineRepository.create({
-      ...createSalesOrderLineDto,
-      lineTotal: createSalesOrderLineDto.quantity*createSalesOrderLineDto.unitPrice
+      ...rest,
+      product,
+      lineTotal: createSalesOrderLineDto.quantity * createSalesOrderLineDto.unitPrice,
     });
     return this.salesOrderLineRepository.save(line);
   }

--- a/back/src/modules/Users/users.controller.ts
+++ b/back/src/modules/Users/users.controller.ts
@@ -13,6 +13,7 @@ import {
 } from '@nestjs/common';
 import { UsersService } from './users.service';
 import { AuthGuard } from '../Auth/guards/auth.guard';
+import { RolesGuard } from '../Auth/guards/roles.guard';
 import { Roles } from '../Decorators/roles.decorator';
 import { Role } from './roles.enum';
 import { ApiBearerAuth, ApiTags, ApiBody } from '@nestjs/swagger';
@@ -22,6 +23,7 @@ import { CreateUserDto, UpdateUserDto } from './dto/userDto';
 @ApiTags('users')
 @Controller('users')
 @ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
@@ -32,20 +34,19 @@ export class UsersController {
   }
 
   @Get(':id')
-  @UseGuards(AuthGuard)
   getUser(@Param('id', ParseUUIDPipe) id: string) {
     return this.usersService.getOneUser(id);
   }
 
   @Post()
-  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
   @ApiBody({ type: CreateUserDto })
   createUser(@Body() user: CreateUserDto) {
     return this.usersService.createUser(user);
   }
 
   @Put(':id')
-  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
   @ApiBody({ type: UpdateUserDto })
   async updateUser(
     @Param('id', ParseUUIDPipe) id: string,
@@ -55,13 +56,13 @@ export class UsersController {
   }
 
   @Delete(':id')
-  @UseGuards(AuthGuard)
+  @Roles(Role.Admin)
   deleteUser(@Param('id', ParseUUIDPipe) id: string) {
     return this.usersService.deleteUser(id);
   }
 
   @Patch(':id')
-  @ApiBearerAuth()
+  @Roles(Role.Admin)
   async convertUser(
     @Param('id', ParseUUIDPipe) id: string,
     @Body() user: Partial<Users>,

--- a/back/src/modules/caja/caja/caja.controller.ts
+++ b/back/src/modules/caja/caja/caja.controller.ts
@@ -1,11 +1,15 @@
-import { Controller, Get, Post, Body, Param, Put, Query } from '@nestjs/common';
+import { Controller, Get, Post, Body, Param, Put, Query, UseGuards } from '@nestjs/common';
 import { CajaService } from './caja.service';
 import { CreateCajaDto } from './dto/create-caja.dto';
 import { UpdateCajaDto } from './dto/update-caja.dto';
-import { ApiTags, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiQuery, ApiBearerAuth } from '@nestjs/swagger';
+import { AuthGuard } from '../../Auth/guards/auth.guard';
+import { RolesGuard } from '../../Auth/guards/roles.guard';
 
 @ApiTags('caja')
 @Controller('caja')
+@ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class CajaController {
   constructor(private readonly cajaService: CajaService) {}
 

--- a/back/src/modules/caja/caja/caja.module.ts
+++ b/back/src/modules/caja/caja/caja.module.ts
@@ -6,9 +6,15 @@ import { Caja } from './entities/caja.entity';
 import { Movimiento } from '../movimientos/entities/movimiento.entity';
 import { Users } from 'src/modules/Users/entities/users.entity';
 import { Location } from 'src/modules/Location/entities/location.entity';
+import { AuthModule } from '../../Auth/auth.module';
+import { UsersModule } from '../../Users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Caja, Users, Location, Movimiento])],
+  imports: [
+    TypeOrmModule.forFeature([Caja, Users, Location, Movimiento]),
+    AuthModule,
+    UsersModule,
+  ],
   controllers: [CajaController],
   providers: [CajaService],
 })

--- a/back/src/modules/caja/movimientos/movimientos.controller.ts
+++ b/back/src/modules/caja/movimientos/movimientos.controller.ts
@@ -6,14 +6,21 @@ import {
   Param,
   Delete,
   Req,
+  UseGuards,
 } from '@nestjs/common';
 import { MovimientosService } from './movimientos.service';
 import { CreateMovimientoDto } from './dto/create-movimiento.dto';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { Movimiento } from './entities/movimiento.entity';
+import { AuthGuard } from '../../Auth/guards/auth.guard';
+import { RolesGuard } from '../../Auth/guards/roles.guard';
+import { Roles } from '../../Decorators/roles.decorator';
+import { Role } from '../../Users/roles.enum';
 
 @ApiTags('movimientos')
 @Controller('movimientos')
+@ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class MovimientosController {
   constructor(private readonly movimientosService: MovimientosService) {}
 
@@ -44,6 +51,7 @@ export class MovimientosController {
   }
 
   @ApiOperation({ summary: 'Eliminar un movimiento' })
+  @Roles(Role.Admin)
   @Delete(':id')
   remove(@Param('id') id: string) {
     return this.movimientosService.remove(id);

--- a/back/src/modules/caja/movimientos/movimientos.module.ts
+++ b/back/src/modules/caja/movimientos/movimientos.module.ts
@@ -3,9 +3,15 @@ import { MovimientosService } from './movimientos.service';
 import { MovimientosController } from './movimientos.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Movimiento } from './entities/movimiento.entity';
+import { AuthModule } from '../../Auth/auth.module';
+import { UsersModule } from '../../Users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Movimiento])],
+  imports: [
+    TypeOrmModule.forFeature([Movimiento]),
+    AuthModule,
+    UsersModule,
+  ],
   controllers: [MovimientosController],
   providers: [MovimientosService],
   exports: [MovimientosService]

--- a/back/src/modules/products/products.controller.ts
+++ b/back/src/modules/products/products.controller.ts
@@ -6,18 +6,26 @@ import {
   Param,
   Delete,
   Put,
+  UseGuards,
 } from '@nestjs/common';
 import { ProductsService } from './products.service';
 import { CreateProductDto } from './dto/create-product.dto';
 import { UpdateProductDto } from './dto/update-product.dto';
-import { ApiTags, ApiOperation, ApiParam } from '@nestjs/swagger';
+import { ApiTags, ApiOperation, ApiParam, ApiBearerAuth } from '@nestjs/swagger';
+import { AuthGuard } from '../Auth/guards/auth.guard';
+import { RolesGuard } from '../Auth/guards/roles.guard';
+import { Roles } from '../Decorators/roles.decorator';
+import { Role } from '../Users/roles.enum';
 
 @ApiTags('products')
 @Controller('products')
+@ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class ProductsController {
   constructor(private readonly productsService: ProductsService) {}
 
   @Post()
+  @Roles(Role.Admin)
   @ApiOperation({ summary: 'Crear un nuevo producto' })
   createProduct(@Body() createProductDto: CreateProductDto) {
     return this.productsService.createProduct(createProductDto);
@@ -37,6 +45,7 @@ export class ProductsController {
   }
 
   @Put(':id')
+  @Roles(Role.Admin)
   @ApiOperation({ summary: 'Actualizar un producto existente' })
   @ApiParam({ name: 'id', description: 'ID del producto' })
   updateProduct(
@@ -47,6 +56,7 @@ export class ProductsController {
   }
 
   @Delete(':id')
+  @Roles(Role.Admin)
   @ApiOperation({ summary: 'Desactivar un producto' })
   @ApiParam({ name: 'id', description: 'ID del producto' })
   removeProduct(@Param('id') id: string) {

--- a/back/src/modules/products/products.module.ts
+++ b/back/src/modules/products/products.module.ts
@@ -4,11 +4,18 @@ import { ProductsController } from './products.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Product } from './entities/product.entity';
 import { ProductRepository } from './products.repository';
-import { LocationModule } from '../Location/location.module'; 
+import { LocationModule } from '../Location/location.module';
 import { Location } from '../Location/entities/location.entity';
+import { AuthModule } from '../Auth/auth.module';
+import { UsersModule } from '../Users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Product, Location]), LocationModule], 
+  imports: [
+    TypeOrmModule.forFeature([Product, Location]),
+    LocationModule,
+    AuthModule,
+    UsersModule,
+  ],
   controllers: [ProductsController],
   providers: [ProductsService, ProductRepository],
   exports: [ProductRepository, ProductsService],

--- a/back/src/modules/reservations/reservation.controller.ts
+++ b/back/src/modules/reservations/reservation.controller.ts
@@ -15,15 +15,22 @@ import {
   Req,
   HttpStatus,
   ParseIntPipe,
+  UseGuards,
 } from '@nestjs/common';
-import { ApiTags, ApiResponse, ApiQuery, ApiParam } from '@nestjs/swagger'; // Importa los decoradores necesarios
+import { ApiTags, ApiResponse, ApiQuery, ApiParam, ApiBearerAuth } from '@nestjs/swagger'; // Importa los decoradores necesarios
 import { ReservationService } from './reservation.service';
 import { CreateReservationDto } from './dto/create-reservation.dto';
 import { UpdateReservationDto } from './dto/update-reservation.dto';
 import { Reservation } from './entities/reservation.entity';
+import { AuthGuard } from '../Auth/guards/auth.guard';
+import { RolesGuard } from '../Auth/guards/roles.guard';
+import { Roles } from '../Decorators/roles.decorator';
+import { Role } from '../Users/roles.enum';
 
 @ApiTags('reservas')
 @Controller('reservations')
+@ApiBearerAuth()
+@UseGuards(AuthGuard, RolesGuard)
 export class ReservationsController {
   constructor(private readonly reservationService: ReservationService) {}
 
@@ -174,6 +181,7 @@ export class ReservationsController {
   }
 
   @Delete(':id')
+  @Roles(Role.Admin)
   @HttpCode(HttpStatus.OK)
   @ApiResponse({
     status: HttpStatus.OK,

--- a/back/src/modules/reservations/reservation.module.ts
+++ b/back/src/modules/reservations/reservation.module.ts
@@ -5,9 +5,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Reservation } from './entities/reservation.entity';
 import { Pax } from 'src/modules/pax/entity/pax.entity';
 import { Room } from 'src/modules/Rooms/entities/rooms.entity';
+import { AuthModule } from '../Auth/auth.module';
+import { UsersModule } from '../Users/users.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Reservation, Pax, Room])],
+  imports: [
+    TypeOrmModule.forFeature([Reservation, Pax, Room]),
+    AuthModule,
+    UsersModule,
+  ],
   controllers: [ReservationsController],
   providers: [ReservationService],
 })

--- a/back/src/modules/reservations/reservation.service.ts
+++ b/back/src/modules/reservations/reservation.service.ts
@@ -159,6 +159,28 @@ export class ReservationService {
       where: { name: createReservationDto.roomType.name},
     });
 
+    if (room) {
+      const overlapping = await this.reservationsRepository
+        .createQueryBuilder('reservation')
+        .where('reservation.roomId = :roomId', { roomId: room.id })
+        .andWhere('reservation.status != :cancelled', {
+          cancelled: Status.Cancelled,
+        })
+        .andWhere('reservation.checkInDate < :checkOutDate', {
+          checkOutDate: createReservationDto.checkOutDate,
+        })
+        .andWhere('reservation.checkOutDate > :checkInDate', {
+          checkInDate: createReservationDto.checkInDate,
+        })
+        .getOne();
+
+      if (overlapping) {
+        throw new BadRequestException(
+          'La habitación ya tiene una reserva activa que se superpone con esas fechas',
+        );
+      }
+    }
+
     //if (!visitor) {
     let visitor = this.paxRepository.create({
       name: createReservationDto.pax.name,

--- a/front/src/Interfaces/IReservation.ts
+++ b/front/src/Interfaces/IReservation.ts
@@ -1,7 +1,7 @@
 import { Pax } from "./IPax";
  
 export interface Room {
-  id: number;
+  id: string;
   roomNumber: string;
   name: string;
   description: string;

--- a/front/src/app/Calendar/page.tsx
+++ b/front/src/app/Calendar/page.tsx
@@ -1,7 +1,12 @@
 import Calendar from "@/components/Calendar/Calendar";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 
 function Page() {
-  return <Calendar />;
+  return (
+    <ProtectedRouteStaff>
+      <Calendar />
+    </ProtectedRouteStaff>
+  );
 }
 
 export default Page;

--- a/front/src/app/CreateOrder/page.tsx
+++ b/front/src/app/CreateOrder/page.tsx
@@ -1,14 +1,17 @@
 import CreateOrder from "@/components/CreateOrder/CreateOrder";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 import Link from "next/link";
 
 function Page() {
   return (
-    <div>
-      <Link href={"/OrderPage"}>
-        <button   className="inline-block rounded bg-[#CD9C8A] text-white px-12 py-3 text-sm font-medium hover:bg-transparent hover:text-[#FF5100] hover:border-[#CD9C8A] hover:border-2 focus:outline-none focus:ring active:text-[#FF5100] transition-all duration-300">Ver Ventas</button>
-      </Link>
-      <CreateOrder />
-    </div>
+    <ProtectedRouteStaff>
+      <div>
+        <Link href={"/OrderPage"}>
+          <button   className="inline-block rounded bg-[#CD9C8A] text-white px-12 py-3 text-sm font-medium hover:bg-transparent hover:text-[#FF5100] hover:border-[#CD9C8A] hover:border-2 focus:outline-none focus:ring active:text-[#FF5100] transition-all duration-300">Ver Ventas</button>
+        </Link>
+        <CreateOrder />
+      </div>
+    </ProtectedRouteStaff>
   );
 }
 

--- a/front/src/app/OptionRes/page.tsx
+++ b/front/src/app/OptionRes/page.tsx
@@ -1,8 +1,11 @@
 import OptionRest from '@/components/OptionRes'
+import ProtectedRouteStaff from '@/components/ProtectedRouteStaff'
 import React from 'react'
 
 export default function page() {
   return (
-    <OptionRest/>
+    <ProtectedRouteStaff>
+      <OptionRest/>
+    </ProtectedRouteStaff>
   )
 }

--- a/front/src/app/OrderPage/page.tsx
+++ b/front/src/app/OrderPage/page.tsx
@@ -1,10 +1,13 @@
 import OrderPage from "../../components/OrderList/OrderList";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 
 function Page() {
   return (
-    <div>
-      <OrderPage />
-    </div>
+    <ProtectedRouteStaff>
+      <div>
+        <OrderPage />
+      </div>
+    </ProtectedRouteStaff>
   );
 }
 

--- a/front/src/app/ResHotel/page.tsx
+++ b/front/src/app/ResHotel/page.tsx
@@ -1,10 +1,13 @@
 import CreateReservationHotel from "../../components/formReservation/CreateReservationHotel";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 
 function Page() {
   return (
-    <div>
-      <CreateReservationHotel />
-    </div>
+    <ProtectedRouteStaff>
+      <div>
+        <CreateReservationHotel />
+      </div>
+    </ProtectedRouteStaff>
   );
 }
 

--- a/front/src/app/ReservationList/page.tsx
+++ b/front/src/app/ReservationList/page.tsx
@@ -1,10 +1,13 @@
 import ListReservation from "@/components/ListReservation/ListReservation";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 
 function Page() {
   return (
-    <div>
-      <ListReservation />
-    </div>
+    <ProtectedRouteStaff>
+      <div>
+        <ListReservation />
+      </div>
+    </ProtectedRouteStaff>
   );
 }
 

--- a/front/src/app/adminDashboard/caja/page.tsx
+++ b/front/src/app/adminDashboard/caja/page.tsx
@@ -1,8 +1,11 @@
 import BuscarCaja from '@/components/Caja/FindBox'
+import ProtectedRoute from '@/components/ProtectedRoute'
 import React from 'react'
 
 export default function page() {
   return (
-    <BuscarCaja/>
+    <ProtectedRoute>
+      <BuscarCaja/>
+    </ProtectedRoute>
   )
 }

--- a/front/src/app/adminDashboard/page.tsx
+++ b/front/src/app/adminDashboard/page.tsx
@@ -1,8 +1,11 @@
 import Panel from '@/components/AdminDashboard/Panel'
+import ProtectedRoute from '@/components/ProtectedRoute'
 import React from 'react'
 
 export default function page() {
   return (
-    <Panel/>
+    <ProtectedRoute>
+      <Panel/>
+    </ProtectedRoute>
   )
 }

--- a/front/src/app/adminDashboard/products/page.tsx
+++ b/front/src/app/adminDashboard/products/page.tsx
@@ -1,13 +1,16 @@
 "use client";
-import React from "react"; 
+import React from "react";
 import AllProducts from "@/components/Products/AllProducts";
+import ProtectedRoute from "@/components/ProtectedRoute";
 
 export default function Productspage() {
 
 
   return (
-    <div className="bg-background text-foreground">
-      <AllProducts />
-    </div>
+    <ProtectedRoute>
+      <div className="bg-background text-foreground">
+        <AllProducts />
+      </div>
+    </ProtectedRoute>
   );
 }

--- a/front/src/app/adminDashboard/upload/page.tsx
+++ b/front/src/app/adminDashboard/upload/page.tsx
@@ -1,13 +1,14 @@
 "use client"
 import React from 'react';
 import CreateProduct from '@/components/Products/CreateProduct';
+import ProtectedRoute from '@/components/ProtectedRoute';
 
 
 
     export default function UploadProducts() {
       return (
-        <>
+        <ProtectedRoute>
       <CreateProduct />
-               </>
+               </ProtectedRoute>
       );
     }

--- a/front/src/app/cashClosing/page.tsx
+++ b/front/src/app/cashClosing/page.tsx
@@ -1,8 +1,11 @@
 import CashClosingForm from '@/components/CashClosing/CashClosingForm'
+import ProtectedRouteStaff from '@/components/ProtectedRouteStaff'
 import React from 'react'
 
 export default function page() {
   return (
-    <CashClosingForm/>
+    <ProtectedRouteStaff>
+      <CashClosingForm/>
+    </ProtectedRouteStaff>
   )
 }

--- a/front/src/app/cashMovementsPage/movements/page.tsx
+++ b/front/src/app/cashMovementsPage/movements/page.tsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 import { useLocationContext } from "@/context/LocationContext";
 import { fetchCashMovements } from "@/components/Fetchs/MovementsFetch.tsx/MovementsFetch";
 import { IMovimientoCaja } from "@/Interfaces/IMovements";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 
 const Movements: React.FC = () => {
   const [movimientosCaja, setMovimientosCaja] = useState<IMovimientoCaja[]>([]);
@@ -64,6 +65,7 @@ const Movements: React.FC = () => {
   };
 
   return (
+    <ProtectedRouteStaff>
     <div className="bg-gradient-to-r font-sans min-h-screen">
     <div className="flex justify-center items-center space-x-2 my-16">
       <h1 className="text-4xl font-bold text-gray-800 tracking-wide">
@@ -172,6 +174,7 @@ const Movements: React.FC = () => {
         <p className="text-center text-xl text-gray-500">No hay movimientos de caja disponibles.</p>
       )}
     </div>
+    </ProtectedRouteStaff>
   );
 };
 

--- a/front/src/app/cashOpening/page.tsx
+++ b/front/src/app/cashOpening/page.tsx
@@ -1,8 +1,11 @@
 import CashOpeningForm from '@/components/CashOpening/CashOpeningForm'
+import ProtectedRouteStaff from '@/components/ProtectedRouteStaff'
 import React from 'react'
 
 export default function page() {
   return (
-    <CashOpeningForm/>
+    <ProtectedRouteStaff>
+      <CashOpeningForm/>
+    </ProtectedRouteStaff>
   )
 }

--- a/front/src/app/expenses/page.tsx
+++ b/front/src/app/expenses/page.tsx
@@ -1,10 +1,13 @@
 "use client"
 import ExpensesForm from '@/components/Expenses/ExpensesForm';
+import ProtectedRouteStaff from '@/components/ProtectedRouteStaff';
 import React from 'react';
 
 export default function Page() {
- 
+
   return (
-    <ExpensesForm  />
+    <ProtectedRouteStaff>
+      <ExpensesForm  />
+    </ProtectedRouteStaff>
   );
 }

--- a/front/src/app/location/[id]/products/page.tsx
+++ b/front/src/app/location/[id]/products/page.tsx
@@ -5,8 +5,17 @@ import { useParams } from "next/navigation";
 import { IProduct } from "@/Interfaces/IUser";
 import CardProduct from "@/components/Products/cardProduct";
 import { useProducts } from "@/components/Products/useProduct";
+import ProtectedRouteStaff from "@/components/ProtectedRouteStaff";
 
 export default function LocationProducts() {
+  return (
+    <ProtectedRouteStaff>
+      <LocationProductsView />
+    </ProtectedRouteStaff>
+  );
+}
+
+function LocationProductsView() {
   const { products, loading, toggleProductStatus, handleEditSubmit } =
     useProducts(); // Aquí ya tienes handleEditSubmit
   const [filteredProducts, setFilteredProducts] = useState<IProduct[]>([]);

--- a/front/src/app/location/create/page.tsx
+++ b/front/src/app/location/create/page.tsx
@@ -1,8 +1,11 @@
 import CreateLocation from '@/components/Locations/createLocation'
+import ProtectedRoute from '@/components/ProtectedRoute'
 import React from 'react'
 
 export default function page() {
   return (
-   <CreateLocation/>
+   <ProtectedRoute>
+     <CreateLocation/>
+   </ProtectedRoute>
   )
 }

--- a/front/src/components/Fetchs/CajaFetch/CajaFetch.tsx
+++ b/front/src/components/Fetchs/CajaFetch/CajaFetch.tsx
@@ -1,10 +1,13 @@
 import { ICaja, ICloseCaja, ICreateCaja } from "@/Interfaces/ICaja";
+import { authHeaders } from "@/helpers/authHeaders";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export const fetchFindBoxBy = async (): Promise<ICaja[]> => {
     try {
-      const response = await fetch(`${apiUrl}/caja`);
+      const response = await fetch(`${apiUrl}/caja`, {
+        headers: authHeaders(),
+      });
       if (!response.ok) {
         throw new Error('Error al obtener las cajas.');
       }
@@ -14,12 +17,14 @@ export const fetchFindBoxBy = async (): Promise<ICaja[]> => {
         console.error('Error:', err);
         throw new Error('Ocurrió un error inesperado.');
       }
-      
+
   };
-  
+
   export const fetchFindBoxById = async (id: string): Promise<ICaja> => {
     try {
-      const response = await fetch(`${apiUrl}/caja/${id}`);
+      const response = await fetch(`${apiUrl}/caja/${id}`, {
+        headers: authHeaders(),
+      });
       if (!response.ok) {
         throw new Error('Caja no encontrada.');
       }
@@ -29,7 +34,7 @@ export const fetchFindBoxBy = async (): Promise<ICaja[]> => {
       console.error('Error:', err);
       throw new Error('Ocurrió un error inesperado.');
     }
-    
+
   };
 
 
@@ -37,9 +42,9 @@ export const fetchCreateCaja = async (caja: ICreateCaja) => {
   try {
     const response = await fetch(`${apiUrl}/caja`, {
       method: 'POST',
-      headers: {
+      headers: authHeaders({
         'Content-Type': 'application/json',
-      },
+      }),
       body: JSON.stringify(caja),
     });
     return response.json();
@@ -54,9 +59,9 @@ export const fetchUpdateCaja = async (id: string, caja: ICloseCaja) => {
   try {
     const response = await fetch(`${apiUrl}/caja/${id}`, {
       method: 'PUT',
-      headers: {
+      headers: authHeaders({
         'Content-Type': 'application/json',
-      },
+      }),
       body: JSON.stringify(caja),
     });
 

--- a/front/src/components/Fetchs/MovementsFetch.tsx/MovementsFetch.tsx
+++ b/front/src/components/Fetchs/MovementsFetch.tsx/MovementsFetch.tsx
@@ -1,15 +1,16 @@
 import { ICreateMovement } from "@/Interfaces/IMovements";
+import { authHeaders } from "@/helpers/authHeaders";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export const crearMovimiento = async (movimiento: ICreateMovement) => {
-   
+
       try {
       const response = await fetch(`${apiUrl}/movimientos`, {
         method: 'POST',
-        headers: {
+        headers: authHeaders({
           'Content-Type': 'application/json',
-        },
+        }),
         body: JSON.stringify(movimiento),
       });
   
@@ -29,9 +30,9 @@ export const crearMovimiento = async (movimiento: ICreateMovement) => {
 export const fetchCashMovements = async (locationId:string) => {
   const response = await fetch(`${apiUrl}/movimientos/${locationId}`, {
     method: "GET",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
   });
 
   if (!response.ok) {

--- a/front/src/components/Fetchs/OrdersFetch/IOrdersFetch.tsx
+++ b/front/src/components/Fetchs/OrdersFetch/IOrdersFetch.tsx
@@ -1,15 +1,16 @@
 import { ISalesOrderLines } from "@/Interfaces/IOrders";
 import { ISalesOrders } from "@/Interfaces/IOrders";
+import { authHeaders } from "@/helpers/authHeaders";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export const createSalesOrder = async (data: ISalesOrders) => {
   const response = await fetch(`${apiUrl}/salesOrders`, {
     method: "POST",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data), 
+    }),
+    body: JSON.stringify(data),
   });
 
   if (!response.ok) {
@@ -18,16 +19,16 @@ export const createSalesOrder = async (data: ISalesOrders) => {
     );
   }
 
-  return response.json(); 
+  return response.json();
 };
 export const createSalesOrderLine = async (data: ISalesOrderLines) => {
-  console.log("Datos que se envían al backend:", JSON.stringify(data)); 
+  console.log("Datos que se envían al backend:", JSON.stringify(data));
   try {
     const response = await fetch(`${apiUrl}/salesOrderLines`, {
       method: "POST",
-      headers: {
+      headers: authHeaders({
         "Content-Type": "application/json",
-      },
+      }),
       body: JSON.stringify(data),
     });
 
@@ -50,9 +51,9 @@ export const createSalesOrderLine = async (data: ISalesOrderLines) => {
 export const fetchGetOrders = async () => {
   const response = await fetch(`${apiUrl}/salesOrders`, {
     method: "GET",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
   });
 
   if (!response.ok) {

--- a/front/src/components/Fetchs/ProductsFetchs/ProductsFetchs.tsx
+++ b/front/src/components/Fetchs/ProductsFetchs/ProductsFetchs.tsx
@@ -1,4 +1,5 @@
 import { ICreateProduct, IProduct } from "@/Interfaces/IUser";
+import { authHeaders } from "@/helpers/authHeaders";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
@@ -23,29 +24,31 @@ export const fetchGetProducts = async (token:string) => {
 
   
 export const fetchProductById = async (id:string) => {
-    const response = await fetch(`${apiUrl}/products/${id}`);
+    const response = await fetch(`${apiUrl}/products/${id}`, {
+      headers: authHeaders(),
+    });
     if (!response.ok) {
       throw new Error(`Error al obtener el producto: ${response.statusText}`);
     }
     return await response.json();
   };
-  
 
-  
+
+
   //Modificar producto
   export const fetchUpdateProduct = async(id:string, product:IProduct) => {
     const response = await fetch(`${apiUrl}/products/${id}`, {
       method: "PUT",
-      headers: {
+      headers: authHeaders({
         "Content-Type": "application/json",
-      },
+      }),
       body: JSON.stringify(product),
     });
-  
+
   if (!response.ok) {
   throw new Error("Error al modificar producto");
   }
-  
+
   return response.json();
   };
 
@@ -55,9 +58,9 @@ export const fetchProductById = async (id:string) => {
 export const fetchUploadProduct = async (product:ICreateProduct) => {
     const response = await fetch(`${apiUrl}/products`, {
         method: "POST",
-        headers: {
+        headers: authHeaders({
           "Content-Type": "application/json",
-        },
+        }),
         body: JSON.stringify(product),
       });
 
@@ -75,6 +78,7 @@ console.log(id)
 export const fetchToggleProductStatus = async (id: string) => {
   const response = await fetch(`${apiUrl}/products/${id}`, {
     method: 'DELETE',
+    headers: authHeaders(),
   });
 
   if (!response.ok) {

--- a/front/src/components/Fetchs/ReservationsFetch/IReservationsFetch.tsx
+++ b/front/src/components/Fetchs/ReservationsFetch/IReservationsFetch.tsx
@@ -1,14 +1,15 @@
 import { CreateReservationDto } from "@/Interfaces/IReservation";
+import { authHeaders } from "@/helpers/authHeaders";
 
 const apiUrl = process.env.NEXT_PUBLIC_API_URL;
 
 export const CreateReservation = async (data: CreateReservationDto) => {
   const response = await fetch(`${apiUrl}/reservations`, {
     method: "POST",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
-    body: JSON.stringify(data), 
+    }),
+    body: JSON.stringify(data),
   });
 
   if (!response.ok) {
@@ -24,9 +25,9 @@ export const CreateReservation = async (data: CreateReservationDto) => {
 export const CancelReservation = async (reservationId: string) => {
   const response = await fetch(`${apiUrl}/reservations/${reservationId}/cancel`, {
     method: "PATCH",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    }
+    }),
   });
 
   if (!response.ok) {
@@ -35,15 +36,15 @@ export const CancelReservation = async (reservationId: string) => {
     );
   }
 
-  return true; 
+  return true;
 };
 
 export const CompleteReservation = async (reservationId: string) => {
   const response = await fetch(`${apiUrl}/reservations/${reservationId}/complete`, {
     method: "PATCH",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    }
+    }),
   });
 
   if (!response.ok) {
@@ -72,9 +73,9 @@ export const UpdateReservation = async (
 ) => {
   const response = await fetch(`${apiUrl}/reservations/${reservationId}`, {
     method: "PATCH",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
     body: JSON.stringify(data),
   });
 
@@ -88,9 +89,9 @@ export const UpdateReservation = async (
 export const DeleteReservation = async (reservationId: string) => {
   const response = await fetch(`${apiUrl}/reservations/${reservationId}`, {
     method: "DELETE",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
   });
 
   if (!response.ok) {
@@ -103,9 +104,9 @@ export const DeleteReservation = async (reservationId: string) => {
 export const fetchGetReservtions = async (locationId: string) => {
   const response = await fetch(`${apiUrl}/reservations?page=1&limit=50000${locationId ? '&locationId=' + locationId : '&locationId=""'}`, {
     method: "GET",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
   });
 
   if (!response.ok) {
@@ -118,9 +119,9 @@ export const fetchGetReservtions = async (locationId: string) => {
 export const fetchGetReservtionById = async (reservationId: string) => {
   const response = await fetch(`${apiUrl}/reservations/${reservationId}`, {
     method: "GET",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
   });
 
   if (!response.ok) {
@@ -133,9 +134,9 @@ export const fetchGetReservtionById = async (reservationId: string) => {
 export const fetchGetReservtionsByRoom = async (locationId: string) => {
   const response = await fetch(`${apiUrl}/reservations/byRoom?locationId=${locationId}`, {
     method: "GET",
-    headers: {
+    headers: authHeaders({
       "Content-Type": "application/json",
-    },
+    }),
   });
 
   if (!response.ok) {

--- a/front/src/components/ProtectedRouteStaff.tsx
+++ b/front/src/components/ProtectedRouteStaff.tsx
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+"use client";
+import React, { useContext, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { UserContext } from "@/context/UserContext";
+
+const ProtectedRouteStaff: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isLogged } = useContext(UserContext);
+  const router = useRouter();
+  const [isChecking, setIsChecking] = useState(true);
+
+  useEffect(() => {
+    // Retrasa la lógica hasta que `isLogged` sea válido (se hidrata desde localStorage)
+    const timer = setTimeout(() => {
+      if (!isLogged) {
+        router.push("/login");
+      } else {
+        setIsChecking(false);
+      }
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [isLogged, router]);
+
+  if (isChecking) return null;
+
+  return <>{children}</>;
+};
+
+export default ProtectedRouteStaff;

--- a/front/src/components/formReservation/CreateReservationHotel.tsx
+++ b/front/src/components/formReservation/CreateReservationHotel.tsx
@@ -105,11 +105,41 @@ const CreateReservationHotel: React.FC = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    if (!roomId) {
+      Swal.fire("Falta la habitación", "Seleccioná una habitación antes de continuar.", "warning");
+      return;
+    }
+    if (!checkInDate || !checkOutDate) {
+      Swal.fire("Faltan fechas", "Completá la fecha de check-in y check-out.", "warning");
+      return;
+    }
+    if (checkOutDate <= checkInDate) {
+      Swal.fire("Fechas inválidas", "La fecha de check-out debe ser posterior a la de check-in.", "warning");
+      return;
+    }
+    if (!divisa) {
+      Swal.fire("Falta la divisa", "Seleccioná en qué divisa se cobra la reserva.", "warning");
+      return;
+    }
+    if (!name.trim() || !lastname.trim() || !identification.trim()) {
+      Swal.fire("Faltan datos del pasajero", "Completá nombre, apellido y DNI/Pasaporte.", "warning");
+      return;
+    }
+
     const selectedLocation = JSON.parse(localStorage.getItem("selectedLocation") || '');
 
-    // const locationInfo = await fetchGetLocation(selectedLocation.id, token || '')
-    const roomsData = await fetchGetRoomById(roomId || '', token || '');
-    
+    let roomsData;
+    try {
+      roomsData = await fetchGetRoomById(roomId, token || '');
+    } catch (error) {
+      Swal.fire("Error", "No se pudo obtener la habitación seleccionada.", "error");
+      return;
+    }
+    if (!roomsData || !roomsData[0]) {
+      Swal.fire("Error", "La habitación seleccionada ya no está disponible.", "error");
+      return;
+    }
+
     const newReservation = {
       checkIn: false,
       checkInDate,
@@ -144,7 +174,16 @@ const CreateReservationHotel: React.FC = () => {
       addPax: additionalSections
     };
 
-    // addReservation(newReservation);
+    try {
+      await CreateReservation(newReservation);
+    } catch (error) {
+      Swal.fire(
+        "Error al crear la reserva",
+        error instanceof Error ? error.message : "No se pudo crear la reserva. Intentá de nuevo.",
+        "error"
+      );
+      return;
+    }
 
     Swal.fire({
       title: "Reserva creada",
@@ -154,7 +193,6 @@ const CreateReservationHotel: React.FC = () => {
       confirmButtonText: "Aceptar",
     });
 
-    CreateReservation(newReservation)
     setCheckInDate("");
     setCheckOutDate("");
     setRoomId(null);
@@ -177,6 +215,7 @@ const CreateReservationHotel: React.FC = () => {
     setComments("");
     setArrival("");
     setTotalPrice(0);
+    setDivisa("");
     setAdditionalSections([]);
   };
 
@@ -214,7 +253,7 @@ const CreateReservationHotel: React.FC = () => {
   
       fetchRate();
       loadRooms();
-    }, [location]);
+    }, [location, token]);
 
   return (
     <form

--- a/front/src/helpers/authHeaders.ts
+++ b/front/src/helpers/authHeaders.ts
@@ -1,0 +1,18 @@
+export function getAuthToken(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem("user");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed?.token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function authHeaders(
+  extra: Record<string, string> = {}
+): Record<string, string> {
+  const token = getAuthToken();
+  return token ? { ...extra, Authorization: `Bearer ${token}` } : extra;
+}


### PR DESCRIPTION
Punto de partida: el guard leía payload.sub (que el JWT nunca trae, solo trae `id`), así que cualquier usuario autenticado quedaba resuelto como el primer usuario de la tabla (el admin) en todas las rutas protegidas. Verificado en vivo antes del fix. Fix mínimo y compatible con tokens ya emitidos: el guard ahora lee payload.id.

- Auth: el registro público (/auth/register) ya no permite elegir rol; siempre fuerza "employee". Los roles superiores solo los asigna un admin autenticado vía POST/PUT/PATCH /users.
- Guards: se agrega @UseGuards(AuthGuard, RolesGuard) a los controllers que no tenían ninguna protección (products, SalesOrder, SalesOrderLine, caja, movimientos, reservations, Users), con @Roles(Admin) solo en las operaciones sensibles (borrar, gestión de usuarios). Se ajustan los módulos correspondientes para que puedan resolver las dependencias del guard (JwtService/UsersService).
- Fix de un bug real destapado al mover el orden de imports: dotenv se cargaba como efecto secundario tardío dentro de config/typeorm.ts; se carga ahora explícitamente al inicio de main.ts para no depender del orden de resolución de módulos.
- ValidationPipe global en main.ts: las validaciones de los DTOs (class-validator) eran solo metadata de Swagger y nunca se ejecutaban. Se activa sin whitelist/forbidNonWhitelisted para no romper los DTOs con objetos anidados que no tienen @Type()/@ValidateNested().
- Reservas: se agrega validación de solapamiento de fechas por habitación al crear (permite back-to-back, rechaza superposición real).
- Se corrige el mismo bug de relaciones TypeORM ya visto antes, ahora en SalesOrderLine: productId quedaba NULL porque se pasaba el id plano en vez de resolver la relación `product`.

Frontend:
- Todas las páginas privadas que solo dependían del NavBar para "esconder" botones (sin bloquear la URL directa) ahora están protegidas con ProtectedRouteStaff (login requerido) o ProtectedRoute (admin, páginas de /adminDashboard y creación de ubicación).
- Se centraliza el envío del header Authorization vía helpers/authHeaders en los fetch que nunca lo mandaban (reservas, caja, productos, órdenes, movimientos), necesario para que sigan funcionando con los guards nuevos del backend.
- CreateReservationHotel: ya no avisa "reserva creada con éxito" antes de confirmar que el POST al backend funcionó; agrega validación de fechas/habitación/divisa antes de enviar; corrige un useEffect que dejaba el combo de habitaciones vacío por faltarle `token` en las dependencias.
- Corrige el tipo Room (id era `number`, el backend devuelve UUID string).

Deploy: back y front deben salir juntos (o front primero). Si el back con los guards nuevos sale sin que el front ya mande el token, reservas/ caja/productos/órdenes dejan de funcionar hasta que el front redeploye. No se tocó nada de synchronize/CORS (punto 7), queda pendiente a pedido.